### PR TITLE
Configure rubygems to use --user-install by default

### DIFF
--- a/gemrc
+++ b/gemrc
@@ -1,0 +1,1 @@
+gem: --user-install -n ~/.gem/bin

--- a/profile.d/user_ruby_bin_directory.sh
+++ b/profile.d/user_ruby_bin_directory.sh
@@ -1,0 +1,1 @@
+export PATH="$HOME/.gem/bin:$PATH"


### PR DESCRIPTION
Lets users install gems with a plain `gem install` instead of having to specify `--user-install` manually or adding it to their `.gemrc` each.