### PR TITLE
Use --bindir instead of -n in gemrc

### DIFF
--- a/gemrc
+++ b/gemrc
@@ -1,1 +1,1 @@
-gem: --user-install -n ~/.gem/bin
+gem: --user-install --bindir ~/.gem/bin


### PR DESCRIPTION
--bindir is the long form of -n, but apparently it breaks the gem env command.