### PR TITLE
Harden sshd_config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ group.org
 ssl/certs
 ssl/private
 ssh/ssh_host_*_key
+ssh/ssh_host_*_key.pub
 *-
 *.gz
 alternatives
@@ -75,9 +76,6 @@ hosts
 resolv.conf
 resolvconf/resolv.conf.d/original
 udev/rules.d/70-persistent-net.rules
-ssh/ssh_host_dsa_key.pub
-ssh/ssh_host_ecdsa_key.pub
-ssh/ssh_host_rsa_key.pub
 hostname
 machine-id
 provisor.ini

--- a/ssh/sshd_config
+++ b/ssh/sshd_config
@@ -11,9 +11,9 @@ Protocol 2
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
-#HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security
-UsePrivilegeSeparation yes
+UsePrivilegeSeparation sandbox
 
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600
@@ -89,4 +89,3 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
-PasswordAuthentication yes


### PR DESCRIPTION
- use `UsePrivilegeSeparation sandbox`, which is more strict than `UsePrivilegeSeparation yes` during pre-auth;  
- allow using ed25519 for host keys;  
- remove a duplicate instance of `PasswordAuthentication yes`.