### PR TITLE
Compartment user sessions using pam_namespace

### DIFF
--- a/pam.d/common-session
+++ b/pam.d/common-session
@@ -10,6 +10,5 @@
 session	substack	common-session-noninteractive
 
 session	optional	pam_mkhomedir.so
-session	required	pam_namespace.so  unmnt_remnt
 session	optional	pam_systemd.so
 session	optional	pam_umask.so      usergroups

--- a/pam.d/common-session
+++ b/pam.d/common-session
@@ -10,5 +10,6 @@
 session	substack	common-session-noninteractive
 
 session	optional	pam_mkhomedir.so
+session	required	pam_namespace.so  unmnt_remnt
 session	optional	pam_systemd.so
 session	optional	pam_umask.so      usergroups

--- a/pam.d/common-session-noninteractive
+++ b/pam.d/common-session-noninteractive
@@ -8,6 +8,7 @@
 #
 
 session	required	pam_env.so
+session	required	pam_namespace.so  unmnt_remnt
 session	sufficient	pam_sss.so
 session	sufficient	pam_unix.so
 session	required	pam_deny.so

--- a/security/namespace.conf
+++ b/security/namespace.conf
@@ -23,6 +23,7 @@
 # caution, as it will reduce security and isolation achieved by
 # polyinstantiation.
 #
-#/tmp     /tmp-inst/       	level      root,adm
-#/var/tmp /var/tmp/tmp-inst/   	level      root,adm
-#$HOME    $HOME/$USER.inst/     level
+/tmp      /tmp/inst/           user      root
+/var/tmp  /var/tmp/inst/       user      root
+/run/shm  /run/shm/inst/       user      root
+/run/lock /run/lock/inst/      user      root

--- a/security/namespace.conf
+++ b/security/namespace.conf
@@ -23,7 +23,7 @@
 # caution, as it will reduce security and isolation achieved by
 # polyinstantiation.
 #
+/dev      /dev/inst/           user      root
 /tmp      /tmp/inst/           user      root
 /var/tmp  /var/tmp/inst/       user      root
-/run/shm  /run/shm/inst/       user      root
 /run/lock /run/lock/inst/      user      root

--- a/security/namespace.init
+++ b/security/namespace.init
@@ -1,4 +1,4 @@
-#!/bin/sh -p
+#!/bin/sh
 # It receives polydir path as $1, the instance path as $2,
 # a flag whether the instance dir was newly created (0 - no, 1 - yes) in $3,
 # and user name in $4.

--- a/security/namespace.init
+++ b/security/namespace.init
@@ -2,24 +2,8 @@
 # It receives polydir path as $1, the instance path as $2,
 # a flag whether the instance dir was newly created (0 - no, 1 - yes) in $3,
 # and user name in $4.
-#
-# The following section will copy the contents of /etc/skel if this is a
-# newly created home directory.
+
 if [ "$3" = 1 ]; then
-        # This line will fix the labeling on all newly created directories
-        [ -x /sbin/restorecon ] && /sbin/restorecon "$1"
-        user="$4"
-        passwd=$(getent passwd "$user")
-        homedir=$(echo "$passwd" | cut -f6 -d":")
-        if [ "$1" = "$homedir" ]; then
-                gid=$(echo "$passwd" | cut -f4 -d":")
-                cp -rT /etc/skel "$homedir"
-                chown -R "$user":"$gid" "$homedir"
-                mask=$(awk '/^UMASK/{gsub("#.*$", "", $2); print $2; exit}' /etc/login.defs)
-                mode=$(printf "%o" $((0777 & ~$mask)))
-                chmod ${mode:-700} "$homedir"
-                [ -x /sbin/restorecon ] && /sbin/restorecon -R "$homedir"
-        fi
 fi
 
 exit 0

--- a/security/namespace.init
+++ b/security/namespace.init
@@ -1,9 +1,42 @@
-#!/bin/sh
+#!/bin/sh -e
 # It receives polydir path as $1, the instance path as $2,
 # a flag whether the instance dir was newly created (0 - no, 1 - yes) in $3,
 # and user name in $4.
 
+# If the directory is newly created
 if [ "$3" = 1 ]; then
+    # If we are creating /dev
+    if [ "$1" = "/dev" ]; then
+	# Major and minor number for devices come from
+	# https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/devices.txt
+	mknod -m 666 /dev/null      char  1   3
+	mknod -m 666 /dev/zero      char  1   5
+	mknod -m 666 /dev/full      char  1   7
+	mknod -m 666 /dev/random    char  1   8
+	mknod -m 666 /dev/urandom   char  1   9
+	mknod -m 666 /dev/fuse      char 10 229
+
+	mknod -m 666 /dev/ptmx      char  5   2
+	mknod -m 666 /dev/tty       char  5   0
+	chown root:tty /dev/ptmx /dev/tty
+
+	# Mount devpts
+	mkdir -m 755 /dev/pts
+	mount -t devpts devpts /dev/pts
+
+	# Create the shm directory
+	mkdir -m 1777 /dev/shm
+
+	# Mandatory symlinks
+	ln -s /proc/self/fd  /dev/fd
+	ln -s fd/0           /dev/stdin
+	ln -s fd/1           /dev/stdout
+	ln -s fd/2           /dev/stderr
+	ln -s null           /dev/X0R
+
+	# Recommended symlinks
+	ln -s /run/systemd/journal/dev-log /dev/log
+    fi
 fi
 
 exit 0

--- a/tmpfiles.d/namespaces
+++ b/tmpfiles.d/namespaces
@@ -1,5 +1,5 @@
 #Type Path              Mode UID  GID  Age Argument
+d     /dev/inst         0000 root root -   -
 d     /tmp/inst         0000 root root -   -
 d     /var/tmp/inst     0000 root root -   -
-d     /run/shm/inst     0000 root root -   -
 d     /run/lock/inst    0000 root root -   -

--- a/tmpfiles.d/namespaces
+++ b/tmpfiles.d/namespaces
@@ -1,0 +1,5 @@
+#Type Path              Mode UID  GID  Age Argument
+d     /tmp/inst         0000 root root -   -
+d     /var/tmp/inst     0000 root root -   -
+d     /run/shm/inst     0000 root root -   -
+d     /run/lock/inst    0000 root root -   -


### PR DESCRIPTION
- the unmnt_remnt option makes sudo switch to the destination user's namespace;
- `{/var,}/tmp` and `/run/{shm,lock}` are poly-instantiated on a per-user basis;
  root gets to escape this and see all instances.

I have been fairly conservative, so this shouldn't break anything.
In particular, I would like (in a future patch) to:
- also poly-instantiate `/run/user`, and possibly more things in `/run`, as many services get rather dirty in there;
- ~~have a namespaced `/dev` which only allows access to pseudo-devices (`null`, `zero`, `random`, ...);~~
- enforce “read-onlyness” of the system files (equivalent to `systemd.exec`'s `ProtectSystem=full`);
- only make visible that user's home, to avoid issues like #11.

Also, I discussed with @lrvick the possibility of using network namespacing to give each user their own IPv6 (though this requires getting IPv6 connectivity first ...).