### PR TITLE
Future plans for 'sudo' LDAP group

### DIFF
--- a/sudoers
+++ b/sudoers
@@ -21,7 +21,7 @@ Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/b
 root	ALL=(ALL:ALL) ALL
 
 # Allow members of group sudo to execute any command
-%sudo	ALL=(ALL:ALL) ALL
+%sudo	ALL=(ALL:ALL) NOPASSWD: ALL
 
 # See sudoers(5) for more information on "#include" directives:
 


### PR DESCRIPTION
Use LDAP to add admins to the 'sudo' group to add passwordless sudo.