### PR TITLE
Add package stow

### DIFF
--- a/man/man7/hashbang.7
+++ b/man/man7/hashbang.7
@@ -274,6 +274,8 @@ du - (disc usage) Estimates file space usage on a filesystem.
 
 ncdu - A simple ncurses disk usage analyzer.
 
+stow - A symlink manager. Helpful for managing several locally-installed things.
+
 find - Used to search the filesystem for a particular file.
 
 locate - Searches a prebuilt database for files on a filesystem.

--- a/packages.txt
+++ b/packages.txt
@@ -701,6 +701,7 @@ sssd-krb5-common				install
 sssd-ldap					install
 sssd-proxy					install
 startpar					install
+stow						install
 strace						install
 sudo						install
 systemd						install


### PR DESCRIPTION
[Stow](https://www.gnu.org/software/stow/) is a symlink manager.
This is especially helpful to manage mixtures of local and system-wide installations.