### PR TITLE
Install `command-not-found`

### DIFF
--- a/crontab
+++ b/crontab
@@ -12,5 +12,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 25 6	* * *	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )
 47 6	* * 7	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )
 52 6	1 * *	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )
+
+32 7	* * 7	root	update-command-not-found
 #
 #*/3 * * * * root /etc/cron.hourly/udev.sh

--- a/man/man7/hashbang.7
+++ b/man/man7/hashbang.7
@@ -458,6 +458,10 @@ cpulimit - A program that attempts to limit the cpu usage of a process.
 
 cgroups - (Control Groups) A kernel feature to limit, account, and isolate
 resource usage of process groups.
+
+command-not-found - (Debian) Suggest a package when the user calls a command
+that could not be found.
+
 .SS Window/Session Managers
 
 tmux - An Application used to multiplex several virtual consoles, allowing a

--- a/packages.txt
+++ b/packages.txt
@@ -35,6 +35,7 @@ cloud-initramfs-growroot			install
 cloud-utils					install
 cmake						install
 cmake-data					install
+command-not-found				install
 console-setup					install
 console-setup-linux				install
 coreutils					install


### PR DESCRIPTION
That utility displays the user a helpful message whenever they try to call a command that is unavailable, but could be installed from a package.
The cron job is there to ensure that the command-not-found database is kept up-to-date.

For instance:
```
% 7z
zsh: command not found: 7z
The program '7z' is currently not installed.  To run '7z' please ask your administrator to install the package 'p7zip-full'
7z: command not found
```

Debian's default `bash` configuration and the `zsh` config suggested in https://github.com/hashbang/dotfiles/pull/17 both support this.