### PR TITLE
Fix apt pinning and bring weechat 1.3

### DIFF
--- a/apt/apt.conf.d/99defaultrelease
+++ b/apt/apt.conf.d/99defaultrelease
@@ -1,1 +1,0 @@
-APT::Default-Release "jessie";

--- a/apt/preferences
+++ b/apt/preferences
@@ -1,11 +1,9 @@
+# Give jessie priority over everything
 Package: *
-Pin: release a=stable
-Pin-Priority: 999
-
-Package: *
-Pin: release a=testing
+Pin: release n=jessie
 Pin-Priority: 900
 
+# Give stretch priority over unstable (which has the default 500 priority)
 Package: *
-Pin: release o=Debian
+Pin: release n=stretch
 Pin-Priority: 800

--- a/apt/preferences.d/weechat
+++ b/apt/preferences.d/weechat
@@ -1,0 +1,4 @@
+# Use packages from stretch (if more up-to-date) for weechat
+Package: weechat*
+Pin: release n=stretch
+Pin-Priority: 900

--- a/apt/sources.list
+++ b/apt/sources.list
@@ -4,4 +4,8 @@ deb-src http://ftp.debian.org/debian/  jessie main contrib non-free
 deb http://security.debian.org/ jessie/updates main contrib non-free
 deb-src http://security.debian.org/ jessie/updates main contrib non-free
 
-deb http://ftp.us.debian.org/debian unstable main contrib non-free
+# Newer releases.  Use with care and pin.
+deb http://ftp.debian.org/debian/     stretch main contrib non-free
+deb-src http://ftp.debian.org/debian/ stretch main contrib non-free
+
+deb http://ftp.us.debian.org/debian/ unstable main contrib non-free


### PR DESCRIPTION
- This needs to be reviewed carefully, as I started with fixing the pinning configuration (which was having no effect in its previous state).
- This can be deployed to a single shell server at first.
- No user disconnect is involved: they can use `/upgrade`.