### PR TITLE
apt: Disable etckeeper hooks

### DIFF
--- a/apt/apt.conf.d/05etckeeper
+++ b/apt/apt.conf.d/05etckeeper
@@ -1,5 +1,0 @@
-DPkg::Pre-Invoke       { "if [ -x /usr/bin/etckeeper ]; then etckeeper pre-install; fi"; };
-DPkg::Post-Invoke      { "if [ -x /usr/bin/etckeeper ]; then etckeeper post-install; fi"; };
-
-RPM::Pre-Invoke       { "if [ -x /usr/bin/etckeeper ]; then etckeeper pre-install; fi"; };
-RPM::Post-Invoke      { "if [ -x /usr/bin/etckeeper ]; then etckeeper post-install; fi"; };


### PR DESCRIPTION
This completely disables apt integration for etckeeper, because it creates
  different commits on each server, making their histories diverge.

*If* we do this, we **must** commit (sic) to using to automation for handling the shell servers' configuration, _especially_ for package installs.

_NOTE:_ Do not merge yet, I'm not sure how we should deal with package upgrades that change their conffiles...