### PR TITLE
Add nethack-console package

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -509,6 +509,7 @@ ncurses-term					install
 net-tools					install
 netbase						install
 netcat-traditional				install
+nethack-console					install
 nfacct						install
 node-abbrev					install
 node-ansi					install


### PR DESCRIPTION
Does not require any X11 deps and verified in a clean debian:jessie Docker container

```
root@bb558527e74a:/# apt-cache depends nethack-console
nethack-console
  Depends: nethack-common
  Depends: libc6
  Depends: libncurses5
  Depends: libtinfo5
```