### PR TITLE
etckeeper: Do not attempt to push to GitHub

### DIFF
--- a/etckeeper/etckeeper.conf
+++ b/etckeeper/etckeeper.conf
@@ -40,4 +40,4 @@ LOWLEVEL_PACKAGE_MANAGER=dpkg
 # To push each commit to a remote, put the name of the remote here.
 # (eg, "origin" for git). Space-separated lists of multiple remotes
 # also work (eg, "origin gitlab github" for git).
-PUSH_REMOTE="git@github.com:hashbang/shell-etc.git"
+PUSH_REMOTE=""


### PR DESCRIPTION
This would actually make sense to get the commits made by the apt hooks.
However, this is not working and randomly causes etckeeper to hang, which in turns causes `sync.yml` not to terminate.

I think we should find a better way to deal with commits caused by package installation, but I'm not sure yet what the solution is.