### PR TITLE
postfix: Only accept mail for the local host

### DIFF
--- a/postfix/main.cf
+++ b/postfix/main.cf
@@ -5,7 +5,8 @@ readme_directory    = no
 
 # We serve mail for hashbang.sh only
 mydomain      = hashbang.sh
-mydestination = $mydomain $myhostname
+myorigin      = $mydomain
+mydestination = $myhostname
 alias_maps    = hash:/etc/aliases
 
 # Restrict reception to localhost and mail.#!.sh


### PR DESCRIPTION
Otherwise, mails meant for another @hashbang.sh user are not dispatched to mail.#! but delivered locally.
This makes the assumption that `mail.#!` rewrites recipients to `user@host.#!`, which is implemented in https://github.com/hashbang/docker-postfix/pull/5

As such, this depends on https://github.com/hashbang/docker-postfix/pull/5 being deployed.