### PR TITLE
SSH: Usability & security improvements

### DIFF
--- a/ssh/sshd_config
+++ b/ssh/sshd_config
@@ -9,7 +9,6 @@ Port 22
 Protocol 2
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security

--- a/ssh/sshd_config
+++ b/ssh/sshd_config
@@ -25,7 +25,7 @@ LogLevel INFO
 
 # Authentication:
 LoginGraceTime 120
-PermitRootLogin yes
+PermitRootLogin no
 StrictModes yes
 
 RSAAuthentication yes
@@ -52,7 +52,7 @@ PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 
 # Change to no to disable tunnelled clear text passwords
-PasswordAuthentication yes
+PasswordAuthentication no
 
 # Kerberos options
 #KerberosAuthentication no


### PR DESCRIPTION
- This avoids to leave users wondering why SSH asks them for a password (when they don't have the key).
- This avoids admin's (or root's) passwords getting bruteforced.
- This kills of the insecure mechanism DSA.