### PR TITLE
PAM: Drop Debian's autoconfig

### DIFF
--- a/pam.d/common-account
+++ b/pam.d/common-account
@@ -13,6 +13,7 @@
 # pam-auth-update(8) for details.
 #
 
-account	sufficient                      pam_unix.so 
-account	sufficient			pam_localuser.so 
-account	required			pam_sss.so
+account	sufficient	pam_sss.so
+account	sufficient	pam_unix.so
+account	sufficient	pam_localuser.so
+account	required	pam_deny.so

--- a/pam.d/common-auth
+++ b/pam.d/common-auth
@@ -7,16 +7,7 @@
 # (e.g., /etc/shadow, LDAP, Kerberos, etc.).  The default is to use the
 # traditional Unix authentication mechanisms.
 #
-# As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
-# To take advantage of this, it is recommended that you configure any
-# local modules either before or after the default block, and use
-# pam-auth-update to manage selection of other modules.  See
-# pam-auth-update(8) for details.
 
-# here are the per-package modules (the "Primary" block)
-auth	sufficient                      pam_unix.so nullok_secure
-auth	sufficient                      pam_sss.so use_first_pass
+auth	sufficient                      pam_sss.so
+auth	sufficient                      pam_unix.so nullok_secure use_first_pass
 auth	required			pam_deny.so
-# prime the stack with a positive return value if there isn't one already;
-# this avoids us returning an error just because nothing sets a success code
-# since the modules above will each just jump around

--- a/pam.d/common-auth
+++ b/pam.d/common-auth
@@ -9,5 +9,5 @@
 #
 
 auth	sufficient                      pam_sss.so
-auth	sufficient                      pam_unix.so nullok_secure use_first_pass
+auth	sufficient                      pam_unix.so use_first_pass
 auth	required			pam_deny.so

--- a/pam.d/common-password
+++ b/pam.d/common-password
@@ -15,14 +15,7 @@
 #
 # See the pam_unix manpage for other options.
 
-# As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
-# To take advantage of this, it is recommended that you configure any
-# local modules either before or after the default block, and use
-# pam-auth-update to manage selection of other modules.  See
-# pam-auth-update(8) for details.
-
-# here are the per-package modules (the "Primary" block)
 password	requisite			pam_pwquality.so retry=3
-password	sufficient                      pam_unix.so obscure use_authtok try_first_pass sha512
 password	sufficient			pam_sss.so use_authtok
+password	sufficient                      pam_unix.so obscure use_authtok try_first_pass sha512
 password	requisite			pam_deny.so

--- a/pam.d/common-session
+++ b/pam.d/common-session
@@ -6,17 +6,9 @@
 # at the start and end of sessions of *any* kind (both interactive and
 # non-interactive).
 #
-# As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
-# To take advantage of this, it is recommended that you configure any
-# local modules either before or after the default block, and use
-# pam-auth-update to manage selection of other modules.  See
-# pam-auth-update(8) for details.
 
-session required        pam_env.so
-session	optional	pam_unix.so 
-session	optional	pam_sss.so
-session optional        pam_mkhomedir.so
-# end of pam-auth-update config
+@include common-session-noninteractive
 
-session        optional        pam_systemd.so
-session        optional        pam_umask.so      usergroups
+session	optional	pam_mkhomedir.so
+session	optional	pam_systemd.so
+session	optional	pam_umask.so      usergroups

--- a/pam.d/common-session-noninteractive
+++ b/pam.d/common-session-noninteractive
@@ -6,13 +6,8 @@
 # and should contain a list of modules that define tasks to be performed
 # at the start and end of all non-interactive sessions.
 #
-# As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
-# To take advantage of this, it is recommended that you configure any
-# local modules either before or after the default block, and use
-# pam-auth-update to manage selection of other modules.  See
-# pam-auth-update(8) for details.
 
-# here are the per-package modules (the "Primary" block)
-session required        pam_env.so
-session	optional	pam_unix.so 
-session optional        pam_sss.so
+session	required	pam_env.so
+session	sufficient	pam_sss.so
+session	sufficient	pam_unix.so
+session	required	pam_deny.so


### PR DESCRIPTION
The autoconfig stopped handling our configuration due to “local changes” and using `sudo pam-auth-update --force` to trigger a regen produced a non-functional config (i.e. impossible to login anymore).

In light of this, it feels saner to switch to a hand-managed config and simplify it (since we aren't autogenerating it anymore).