### PR TITLE
fix umask and default environment

### DIFF
--- a/environment
+++ b/environment
@@ -1,0 +1,1 @@
+MAIL=~/Mail

--- a/profile
+++ b/profile
@@ -33,4 +33,4 @@ if [ -d /etc/profile.d ]; then
   unset i
 fi
 
-export MAIL=~/Mail
+umask 700

--- a/zsh/zprofile
+++ b/zsh/zprofile
@@ -5,3 +5,4 @@
 # shells invoked with the -l flag.)
 #
 # Global Order: zshenv, zprofile, zshrc, zlogin
+umask 700


### PR DESCRIPTION
The default environment had MAIL set for only bash, which might create problems with zsh users. I also fixed the umask to default to `077`