### PR TITLE
Install urlview to open links in mutt, weechat, or anywhere else needed

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1067,6 +1067,7 @@ udev						install
 unattended-upgrades				install
 units						install
 unzip						install
+urlview						install
 usbutils					install
 util-linux					install
 util-linux-locales				install


### PR DESCRIPTION
Would it be possible to have urlview installed to easily open links in shell from mutt or weechat? Both of which would require additional scripts to setup, but that easy enough.

Reverse Depends:
  mutt,urlview
  mutt,urlview

Dependencies:

0.9-19+b1 - libc6 (2 2.14) libncurses5 (2 6) libtinfo5 (2 6) mutt (0 (null)) ncftp (16 (null)) lftp (0 (null)) wget (16 (null)) snarf (0 (null)) elinks (16 (null))
www-browser (0 (null))

0.9-19 - libc6 (2 2.3.4) libncurses5 (2 5.5-5~) mutt (0 (null)) ncftp (16 (null)) lftp (0 (null)) wget (16 (null)) snarf (0 (null)) elinks (16 (null))
www-browser (0 (null)) 