### PR TITLE
etckeeper: Do not prompt for password on push

### DIFF
--- a/etckeeper/commit.d/99push
+++ b/etckeeper/commit.d/99push
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/sh -e
 if [ -n "$PUSH_REMOTE" ]; then
 	if [ "$VCS" = git ] && [ -d .git ]; then
 		for REMOTE in $PUSH_REMOTE; do
-			git push "$REMOTE" master || true
+			GIT_SSH_COMMAND="ssh -o PasswordAuthentication=no" git push "$REMOTE" master
 		done
 	elif [ "$VCS" = hg ] && [ -d .hg ]; then
 		for REMOTE in $PUSH_REMOTE; do


### PR DESCRIPTION
- Passes an option to SSH to forbid prompting for a password
- Does not ignore push failures