### PR TITLE
ssh: Permit root login by pubkey only

### DIFF
--- a/ssh/sshd_config
+++ b/ssh/sshd_config
@@ -24,7 +24,7 @@ LogLevel INFO
 
 # Authentication:
 LoginGraceTime 120
-PermitRootLogin no
+PermitRootLogin without-password
 StrictModes yes
 
 RSAAuthentication yes


### PR DESCRIPTION
This is useful in the context of hashbang/admin-tools#12 as it gives admins access to the root account in case of emergency.

I already deployed SSH keys for root (the admins') while testing hashbang/admin-tools#12