### PR TITLE
Sudo improvements

### DIFF
--- a/sudoers
+++ b/sudoers
@@ -11,6 +11,7 @@ Defaults        env_keep+=SSH_AUTH_SOCK
 Defaults	mail_badpass
 Defaults	!requiretty
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults	!tty_tickets
 
 # Host alias specification
 

--- a/sudoers
+++ b/sudoers
@@ -9,6 +9,7 @@
 Defaults	env_reset
 Defaults        env_keep+=SSH_AUTH_SOCK
 Defaults	mail_badpass
+Defaults	!requiretty
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Host alias specification


### PR DESCRIPTION
- Let `sudo` be called outside of a tty; this is required for Ansible SSH pipelining to work.
- Make `sudo` tickets valid for all open terminals of a given user.