### PR TITLE
Disable rsyslog logging to local files

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -58,40 +58,40 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 #
 # First some standard log files.  Log by facility.
 #
-auth,authpriv.*			/var/log/auth.log
-*.*;auth,authpriv.none		-/var/log/syslog
+#auth,authpriv.*			/var/log/auth.log
+#*.*;auth,authpriv.none		-/var/log/syslog
 #cron.*				/var/log/cron.log
-daemon.*			-/var/log/daemon.log
-kern.*				-/var/log/kern.log
-lpr.*				-/var/log/lpr.log
-mail.*				-/var/log/mail.log
-user.*				-/var/log/user.log
+#daemon.*			-/var/log/daemon.log
+#kern.*				-/var/log/kern.log
+#lpr.*				-/var/log/lpr.log
+#mail.*				-/var/log/mail.log
+#user.*				-/var/log/user.log
 
 #
 # Logging for the mail system.  Split it up so that
 # it is easy to write scripts to parse these files.
 #
-mail.info			-/var/log/mail.info
-mail.warn			-/var/log/mail.warn
-mail.err			/var/log/mail.err
+#mail.info			-/var/log/mail.info
+#mail.warn			-/var/log/mail.warn
+#mail.err			/var/log/mail.err
 
 #
 # Logging for INN news system.
 #
-news.crit			/var/log/news/news.crit
-news.err			/var/log/news/news.err
-news.notice			-/var/log/news/news.notice
+#news.crit			/var/log/news/news.crit
+#news.err			/var/log/news/news.err
+#news.notice			-/var/log/news/news.notice
 
 #
 # Some "catch-all" log files.
 #
-*.=debug;\
-	auth,authpriv.none;\
-	news.none;mail.none	-/var/log/debug
-*.=info;*.=notice;*.=warn;\
-	auth,authpriv.none;\
-	cron,daemon.none;\
-	mail,news.none		-/var/log/messages
+#*.=debug;\
+#	auth,authpriv.none;\
+#	news.none;mail.none	-/var/log/debug
+#*.=info;*.=notice;*.=warn;\
+#	auth,authpriv.none;\
+#	cron,daemon.none;\
+#	mail,news.none		-/var/log/messages
 
 #
 # Emergencies are sent to everybody logged in.


### PR DESCRIPTION
Now that systemd-journal is logging to persistant storage, we don't need rsyslog to do so as well.

After deploying, we can `rm /var/log/{auth.log,syslog,daemon.log,kern.log,lpr.log,mail.log,user.log,mail.info,mail.err,mail.warn,news.crit,news.err,news.notice,debug,messages}`