### PR TITLE
Temporary cronjob for fixing gid 3000 files

### DIFF
--- a/cron.hourly/fix-group-3000.sh
+++ b/cron.hourly/fix-group-3000.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+mkdir -p -m 0700 /var/log/fix-group-3000
+umask 0077
+cd /home
+for user in *; do
+    uid="$(id -u "$user")"
+    if [ "$uid" -ne 3000 ]; then
+        find "/home/$user" -group 3000 -print -exec chgrp --no-dereference "$user" '{}' ';' && \
+            echo "User $user had broken files"
+    fi
+done | gzip >> /var/log/fix-group-3000/"$(date '+%Y%m%d-%H%M')".gz


### PR DESCRIPTION
This should be reverted once no `gid 3000` processes are left (except from deleriux2; 3000 is their ID).
~~Also, `mkdir /var/log/fix-group-3000` before deploying.~~