### PR TITLE
Fix luarocks configs

### DIFF
--- a/luarocks/config-5.1.lua
+++ b/luarocks/config-5.1.lua
@@ -1,4 +1,5 @@
-rocks_trees = {
-   home..[[/.luarocks]],
-   [[/usr/local]]
+variables = {
+	LUA_INTERPRETER = "/usr/bin/lua5.1";
+	LUA_INCDIR = "/usr/include/lua5.1";
 }
+rocks_subdir = "/lib/luarocks/rocks-5.1"

--- a/luarocks/config-5.2.lua
+++ b/luarocks/config-5.2.lua
@@ -1,6 +1,7 @@
 export_lua_path = "export LUA_PATH_5_2='%s'";
 export_lua_cpath = "export LUA_CPATH_5_2='%s'";
 variables = {
-	LUA=[[/usr/bin/lua5.2]];
-        LUA_INCDIR=[[/usr/include/lua5.2]];
+	LUA_INTERPRETER = "/usr/bin/lua5.2";
+	LUA_INCDIR = "/usr/include/lua5.2";
 }
+rocks_subdir = "/lib/luarocks/rocks-5.2"


### PR DESCRIPTION
Adding `rocks_subdir` will version rocks, which makes lua5.1 sit more happily next to lua5.2.
However, it will require all users that have used luarocks to reinstall their rocks.

Added explicit paths for lua5.1 interpreter and includes.