### PR TITLE
apt: Pull ansible from Stretch

### DIFF
--- a/apt/preferences.d/ansible
+++ b/apt/preferences.d/ansible
@@ -1,0 +1,3 @@
+Package: ansible ieee-data python-netaddr
+Pin: release n=stretch
+Pin-Priority: 990


### PR DESCRIPTION
This should help making sure all admins have access to an Ansible 2 install, for hashbang/shell-etc#14.