### PR TITLE
ncurses-doc added

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -792,6 +792,7 @@ nano						install
 ncdu						install
 ncurses-base					install
 ncurses-bin					install
+ncurses-doc					install
 ncurses-term					install
 net-tools					install
 netbase						install


### PR DESCRIPTION
Add ncurses-doc (which consists of man pages for ncurses functions) into the packages list.