### PR TITLE
resolvconf: Set domain as hashbang.sh

### DIFF
--- a/resolvconf/resolv.conf.d/tail
+++ b/resolvconf/resolv.conf.d/tail
@@ -1,0 +1,1 @@
+domain hashbang.sh


### PR DESCRIPTION
This lets relative hostnames, like `da1`, get resolved as `da1.hashbang.sh`, when the host exists.