### PR TITLE
setup.sh improvements

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,7 +30,7 @@ cd /etc
 rm -rf .git
 git init
 git remote add origin https://github.com/hashbang/shell-etc.git
-git fetch --all
+git fetch origin master
 git reset --hard origin/master
 git clean -d -f
 etckeeper init # Apply the correct file permissions

--- a/setup.sh
+++ b/setup.sh
@@ -35,6 +35,10 @@ git reset --hard origin/master
 git clean -d -f
 etckeeper init # Apply the correct file permissions
 
+# Take /etc/default/grub into account
+update-grub
+
+
 # Disable users knowing about other users
 chmod o-r /var/run/utmp # Used by who(1)
 chmod o-r /var/log/wtmp # Used by last(1)

--- a/setup.sh
+++ b/setup.sh
@@ -41,10 +41,4 @@ chmod o-r /var/log/wtmp # Used by last(1)
 chmod o-r /var/log/lastlog # Used by lastlog(8)
 chmod o-r /home # prevent listing of all home dirs.
 
-# Install grub to all devices (overkill, but safe)
-grub-install /dev/sda
-
-# Update initramfs to include repartioning logic
-update-initramfs -u
-
 reboot


### PR DESCRIPTION
- Uses the cleaner way of handling the package set.
- Sets up `/etc` with correct file permissions.
- Do not setup SELinux (it was removed in #66).
- Correctly handles `grub`.
- Sets access rights that are consistent with what is currently deployed.