### PR TITLE
Use deb.debian.org as general-purpose & security mirror

### DIFF
--- a/apt/sources.list
+++ b/apt/sources.list
@@ -1,13 +1,13 @@
-deb http://httpredir.debian.org/debian/  jessie main contrib non-free
-deb-src http://httpredir.debian.org/debian/  jessie main contrib non-free
+deb     http://deb.debian.org/debian/          jessie           main contrib non-free
+deb-src http://deb.debian.org/debian/          jessie           main contrib non-free
 
-deb http://security.debian.org/ jessie/updates main contrib non-free
-deb-src http://security.debian.org/ jessie/updates main contrib non-free
+deb     http://deb.debian.org/debian-security/ jessie/updates   main contrib non-free
+deb-src http://deb.debian.org/debian-security/ jessie/updates   main contrib non-free
 
 # Backports.  Must be enabled per-package using a pin
-deb http://httpredir.debian.org/debian/      jessie-backports main contrib non-free
-deb-src http://httpredir.debian.org/debian/  jessie-backports main contrib non-free
+deb     http://deb.debian.org/debian/          jessie-backports main contrib non-free
+deb-src http://deb.debian.org/debian/          jessie-backports main contrib non-free
 
 # Newer releases.  Use with care and pin.
-deb http://httpredir.debian.org/debian/     stretch main contrib non-free
-deb-src http://httpredir.debian.org/debian/ stretch main contrib non-free
+deb     http://deb.debian.org/debian/          stretch          main contrib non-free
+deb-src http://deb.debian.org/debian/          stretch          main contrib non-free

--- a/apt/sources.list
+++ b/apt/sources.list
@@ -11,3 +11,6 @@ deb-src http://deb.debian.org/debian/          jessie-backports main contrib non
 # Newer releases.  Use with care and pin.
 deb     http://deb.debian.org/debian/          stretch          main contrib non-free
 deb-src http://deb.debian.org/debian/          stretch          main contrib non-free
+
+deb     http://deb.debian.org/debian-security/ stretch/updates  main contrib non-free
+deb-src http://deb.debian.org/debian-security/ stretch/updates  main contrib non-free


### PR DESCRIPTION
We were missing a security mirror for stretch, that's pretty bad.  :-(

This makes us use `deb.debian.org` as a mirror, which is (currently) backed by Fastly's CDN, and officially supported by Debian.
Unfortunately, it turns out that `httpredir.debian.org` is currently not actively maintained.
This should solve the “unreliable mirror” issues that @lrvick encountered.