### PR TITLE
apt: Never install silently from testing

### DIFF
--- a/apt/preferences
+++ b/apt/preferences
@@ -3,7 +3,12 @@ Package: *
 Pin: release n=jessie
 Pin-Priority: 900
 
-# Give backports priority over stretch (which has the default 500 priority)
+# Give backports priority over stretch
 Package: *
 Pin: release n=jessie-backports
 Pin-Priority: 800
+
+# Never silently install from testing
+Package: *
+Pin: release n=stretch
+Pin-Priority: -1


### PR DESCRIPTION
This has caused too many issues, and I just replaced the last package that was pulling in stretch's `libstdc++6`, creating ABI breakage.

It is still possible to install things from `stretch`, by explicitely listing those packages in a pin.
The difference is that a package that doesn't exist in `jessie` or `jessie-backports` won't be silently installed from `stretch` anymore.