### PR TITLE
etckeeper: Push to a dedicated branch

### DIFF
--- a/etckeeper/commit.d/99push
+++ b/etckeeper/commit.d/99push
@@ -2,7 +2,7 @@
 if [ -n "$PUSH_REMOTE" ]; then
 	if [ "$VCS" = git ] && [ -d .git ]; then
 		for REMOTE in $PUSH_REMOTE; do
-			GIT_SSH_COMMAND="ssh -o PasswordAuthentication=no" git push "$REMOTE" master
+			GIT_SSH_COMMAND="ssh -o PasswordAuthentication=no" git push "$REMOTE" "master:$PUSH_BRANCH"
 		done
 	elif [ "$VCS" = hg ] && [ -d .hg ]; then
 		for REMOTE in $PUSH_REMOTE; do

--- a/etckeeper/etckeeper.conf
+++ b/etckeeper/etckeeper.conf
@@ -40,4 +40,5 @@ LOWLEVEL_PACKAGE_MANAGER=dpkg
 # To push each commit to a remote, put the name of the remote here.
 # (eg, "origin" for git). Space-separated lists of multiple remotes
 # also work (eg, "origin gitlab github" for git).
-PUSH_REMOTE="git@github.com:hashbang/shell-etc.git"
+PUSH_REMOTE="git@git-infra.hashbang.sh:shell-etc.git"
+PUSH_BRANCH=${HOSTNAME}

--- a/sudoers
+++ b/sudoers
@@ -7,7 +7,6 @@
 # See the man page for details on how to write a sudoers file.
 #
 Defaults	env_reset
-Defaults        env_keep+=SSH_AUTH_SOCK
 Defaults	mail_badpass
 Defaults	!requiretty
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
This makes `etckeeper` push to `git-infra.hashbang.sh`, on a dedicated branch.
Updates are still pulled from the `master` branch of `shell-etc`, on Github.

This impacts the admin's workflow as follows:
- Nothing changes when deploying updates pulled from `master`: as usual, just to `ansible-playbook shell.yml`.
- When dealing with on-server modifications (typically, security upgrades):
  1. fetch the server branches from `git-infra.hashbang.sh` (`git fetch -a`);
  2. review the changes (typically, did all the servers undergo the same change?);
  3. do a signed merge into master: `git merge -S da1 ny1 sf1 to1`;
  4. `push` to Github.