### PR TITLE
etckeeper: Add `push` subcommand

### DIFF
--- a/etckeeper/push.d/99push
+++ b/etckeeper/push.d/99push
@@ -1,0 +1,1 @@
+../commit.d/99push


### PR DESCRIPTION
This will make it more convenient to update the state in `git-infra` when changes are pulled from `master` (i.e. add a call to `etckeeper push` in Ansible if new changes were received).