### PR TITLE
firejail: Allow mutt to read its own config

### DIFF
--- a/firejail/mutt.profile
+++ b/firejail/mutt.profile
@@ -10,6 +10,11 @@ whitelist ~/Mail
 whitelist ~/sent
 whitelist ~/postponed
 
+# Allow access to mutt and msmtp config
+whitelist ~/.muttrc
+whitelist ~/.mutt/
+whitelist ~/.msmtprc
+
 # Allow executing /usr/sbin/sendmail
 noblacklist /usr/sbin
 


### PR DESCRIPTION
This breaks a few bits of mutt config, for people who have a custom one...