### PR TITLE
Sysctl tuning

### DIFF
--- a/sysctl.conf
+++ b/sysctl.conf
@@ -63,3 +63,7 @@ vm.swappiness = 60
 
 # Use CoDel (controlled delay) to avoid bufferbloat
 net.core.default_qdisc = fq_codel
+
+# Forbid unprivileged (~ CAP_SYS_ADMIN) processes to
+#  instrument the kernel with perf_event_open(2)
+kernel.perf_event_paranoid = 2

--- a/sysctl.conf
+++ b/sysctl.conf
@@ -60,3 +60,6 @@
 #
 net.ipv4.conf.eth0.arp_notify = 1
 vm.swappiness = 60
+
+# Use CoDel (controlled delay) to avoid bufferbloat
+net.core.default_qdisc = fq_codel


### PR DESCRIPTION
- [x] Use CoDel for packet scheduling.
  Might reduce IRC lag issues that @ChickenNuggers encountered, and is a good practice anyhow.
- [x] Forbid unprivileged kernel tracing.
  That has been used in quite a few exploits.