### PR TITLE
Firejail fixup

### DIFF
--- a/firejail/mutt.profile
+++ b/firejail/mutt.profile
@@ -2,18 +2,14 @@
 
 # In case GnuPG is called
 noblacklist ~/.gnupg
-mkdir ~/.gnupg
-whitelist ~/.gnupg
 
-# Allow access to mailboxes
-whitelist ~/Mail
-whitelist ~/sent
-whitelist ~/postponed
+# Only allow R/O access to the home directory
+read-only ~/
 
-# Allow access to mutt and msmtp config
-whitelist ~/.muttrc
-whitelist ~/.mutt/
-whitelist ~/.msmtprc
+# Allow write access to mailboxes
+read-write ~/Mail
+read-write ~/sent
+read-write ~/postponed
 
 # Allow executing /usr/sbin/sendmail
 noblacklist /usr/sbin

--- a/firejail/weechat.profile
+++ b/firejail/weechat.profile
@@ -1,11 +1,9 @@
 # Weechat IRC profile
-noblacklist ${HOME}/.dotfiles/weechat
-noblacklist ${HOME}/.weechat
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 
-read-write  ${HOME}/.dotfiles/weechat
+whitelist ${HOME}/.dotfiles/weechat
+whitelist ${HOME}/.weechat
 
 caps.drop all
 netfilter

--- a/firejail/weechat.profile
+++ b/firejail/weechat.profile
@@ -1,7 +1,11 @@
 # Weechat IRC profile
+noblacklist ${HOME}/.dotfiles/weechat
 noblacklist ${HOME}/.weechat
+
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
+
+read-write  ${HOME}/.dotfiles/weechat
 
 caps.drop all
 netfilter
@@ -12,4 +16,4 @@ seccomp
 
 # no private-bin support for various reasons:
 # Plugins loaded: alias, aspell, charset, exec, fifo, guile, irc,
-# logger, lua, perl, python, relay, ruby, script, tcl, trigger, xferloading plugins 
+# logger, lua, perl, python, relay, ruby, script, tcl, trigger, xferloading plugins


### PR DESCRIPTION
- [x] Fixup mutt profile
  - Enable R/O access to the home directory
  - Enables R/W access to the maildirs
- [x] Fixup weechat profile (R/O access to `~/.dotfiles/weechat`)
- [x] Harden weechat profile by using directory whitelisting (no more access to the whole homedir)

Thanks to @gmcclins for the report.