### PR TITLE
sysctl: Enable reverse-path filtering

### DIFF
--- a/sysctl.conf
+++ b/sysctl.conf
@@ -16,8 +16,8 @@
 # Uncomment the next two lines to enable Spoof protection (reverse-path filter)
 # Turn on Source Address Verification in all interfaces to
 # prevent some spoofing attacks
-#net.ipv4.conf.default.rp_filter=1
-#net.ipv4.conf.all.rp_filter=1
+net.ipv4.conf.default.rp_filter=1
+net.ipv4.conf.all.rp_filter=1
 
 # Uncomment the next line to enable TCP/IP SYN cookies
 # See http://lwn.net/Articles/277146/


### PR DESCRIPTION
This prevents other computers on the same LAN from defeating firewalling (or even reach services that only listen on localhost) by sending packets with spoofed source- and destination-address.