### PR TITLE
Make user-writable ${PATH} and lib directories read-only

### DIFF
--- a/firejail/disable-common.inc
+++ b/firejail/disable-common.inc
@@ -106,6 +106,7 @@ read-only ${HOME}/.xscreensaver
 # Make directories that can override $PATH or libs read-only
 read-only ${HOME}/bin
 read-only ${HOME}/.gem
+read-only ${HOME}/.local
 read-only ${HOME}/.npm-packages
 
 # top secret

--- a/firejail/disable-common.inc
+++ b/firejail/disable-common.inc
@@ -105,6 +105,7 @@ read-only ${HOME}/.xscreensaver
 
 # Make directories that can override $PATH or libs read-only
 read-only ${HOME}/bin
+read-only ${HOME}/.gem
 read-only ${HOME}/.npm-packages
 
 # top secret

--- a/firejail/disable-common.inc
+++ b/firejail/disable-common.inc
@@ -103,7 +103,7 @@ read-only ${HOME}/.reportbugrc
 read-only ${HOME}/.xmonad
 read-only ${HOME}/.xscreensaver
 
-# The user ~/bin directory can override commands such as ls
+# Make directories that can override $PATH or libs read-only
 read-only ${HOME}/bin
 read-only ${HOME}/.npm-packages
 

--- a/firejail/disable-common.inc
+++ b/firejail/disable-common.inc
@@ -107,6 +107,7 @@ read-only ${HOME}/.xscreensaver
 read-only ${HOME}/bin
 read-only ${HOME}/.gem
 read-only ${HOME}/.local
+read-only ${HOME}/.luarocks
 read-only ${HOME}/.npm-packages
 
 # top secret


### PR DESCRIPTION
This makes the following directories read-only, that can be used to override executables or libs:
- [x] `~/.gem`
- [x] `~/.local`
- [x] `~/.luarocks`