### PR TITLE
Use TLS to reach ldap.hashbang.sh

### DIFF
--- a/nslcd.conf
+++ b/nslcd.conf
@@ -7,7 +7,7 @@ uid nslcd
 gid nslcd
 
 # The location at which the LDAP server(s) should be reachable.
-uri ldap://104.236.225.121/
+uri ldaps://ldap.hashbang.sh/
 
 # The search base that will be used for all queries.
 base dc=hashbang,dc=sh

--- a/sssd/sssd.conf
+++ b/sssd/sssd.conf
@@ -10,7 +10,7 @@ config_file_version = 2
 enumerate = TRUE
 id_provider = ldap
 access_provider = ldap
-ldap_uri = ldap://ldap.hashbang.sh
+ldap_uri = ldaps://ldap.hashbang.sh
 ldap_search_base = dc=hashbang,dc=sh
 ldap_tls_reqcert = demand
 ldap_user_search_base = ou=People,dc=hashbang,dc=sh


### PR DESCRIPTION
- [x] Fixes `nslcd.conf`, which pointed to some non-responsive IP address
- [x] Systematically use LDAPS (in `sssd.conf` and `nslcd.conf`)

The only process that uses any sort of LDAP credentials, `hashbangctl`, already used TLS.

However, the ability to compromise a server's view of `passwd` and `group` is very much a security issue.