### PR TITLE
systemd: Disable atd & cron

### DIFF
--- a/systemd/system/crontab.target
+++ b/systemd/system/crontab.target
@@ -1,0 +1,7 @@
+[Install]
+WantedBy=multi-user.target
+
+[Unit]
+Description=Simulates cron, limited to /etc/cron.* 
+Requires=crontab@hour.timer crontab@day.timer
+Requires=crontab@week.timer crontab@month.timer

--- a/systemd/system/crontab@.service
+++ b/systemd/system/crontab@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=%Ily job for /etc/cron.%Ily
+RefuseManualStart=yes
+RefuseManualStop=yes
+ConditionDirectoryNotEmpty=/etc/cron.%Ily
+
+[Service]
+Type=oneshot
+IgnoreSIGPIPE=no
+WorkingDirectory=/
+ExecStart=/bin/run-parts --report /etc/cron.%Ily

--- a/systemd/system/crontab@.timer
+++ b/systemd/system/crontab@.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=%Ily timer simulating /etc/cron.%Ily
+PartOf=crontab.target
+RefuseManualStart=yes
+RefuseManualStop=yes
+
+[Timer]
+OnCalendar=1 %I
+Persistent=yes

--- a/systemd/system/crontab@day.service
+++ b/systemd/system/crontab@day.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily job for /etc/cron.daily
+RefuseManualStart=yes
+RefuseManualStop=yes
+ConditionDirectoryNotEmpty=/etc/cron.daily
+
+[Service]
+Type=oneshot
+IgnoreSIGPIPE=no
+WorkingDirectory=/
+ExecStart=/bin/run-parts --report /etc/cron.daily

--- a/systemd/system/multi-user.target.wants/atd.service
+++ b/systemd/system/multi-user.target.wants/atd.service
@@ -1,1 +1,0 @@
-/lib/systemd/system/atd.service

--- a/systemd/system/multi-user.target.wants/cron.service
+++ b/systemd/system/multi-user.target.wants/cron.service
@@ -1,1 +1,0 @@
-/lib/systemd/system/cron.service

--- a/systemd/system/multi-user.target.wants/crontab.target
+++ b/systemd/system/multi-user.target.wants/crontab.target
@@ -1,0 +1,1 @@
+../crontab.target


### PR DESCRIPTION
Those services can be used to run programs outside a user's slice, bypassing resources limits.