### PR TITLE
Update z_manpath.sh

### DIFF
--- a/profile.d/z_manpath.sh
+++ b/profile.d/z_manpath.sh
@@ -1,1 +1,1 @@
-export MANPATH="$(manpath)"
+export MANPATH="${MANPATH:-$(manpath)}"


### PR DESCRIPTION
It is run in every shell instance, not only for login shells, avoid executing manpath when already set.
`manpath: warning: $MANPATH set, ignoring /etc/manpath.config`