### PR TITLE
sssd: Disable debug logs

### DIFF
--- a/sssd/sssd.conf
+++ b/sssd/sssd.conf
@@ -19,7 +19,6 @@ ldap_pwd_policy = none
 ldap_access_order = host
 ldap_user_authorized_host = host
 cache_credentials = true
-debug_level = 7
 
 [pam]
 id_provider = proxy


### PR DESCRIPTION
I'm unsure why this was enabled, but it consumed all the space on the rootfs of several servers, making them borderline-unuseable.