### PR TITLE
cron.daily/clean-lurkers: Proper user ranges

### DIFF
--- a/cron.daily/clean-lurkers
+++ b/cron.daily/clean-lurkers
@@ -3,14 +3,10 @@
 
 DAYS=30
 
-USERS=`
-lastlog -b $DAYS -u 3000-65533         | \
-    tail -n +2                         | \
-    awk '{print $1}'
-`
-
-for i in $USERS; do
-    if [ ! -f /home/$i/.keep-account ]; then
-	loginctl terminate-user $i
-    fi
+for range in 1000-59999 65536-4294967293; do
+    for user in lastlog -b "$DAYS" -u "$RANGE" | tail -n +2 | cut -d' ' -f1; do
+	if [ ! -f "/home/${user}/.keep-account" ]; then
+	    loginctl terminate-user "$user"
+	fi
+    done
 done

--- a/cron.daily/clean-lurkers
+++ b/cron.daily/clean-lurkers
@@ -4,9 +4,10 @@
 DAYS=30
 
 for range in 1000-59999 65536-4294967293; do
-    for user in lastlog -b "$DAYS" -u "$RANGE" | tail -n +2 | cut -d' ' -f1; do
-	if [ ! -f "/home/${user}/.keep-account" ]; then
-	    loginctl terminate-user "$user"
-	fi
+    for user in lastlog -b "$DAYS" -t "$(($DAYS + 2))" -u "$RANGE" | \
+                  tail -n +2 | cut -d' ' -f1; do
+        if [ ! -f "/home/${user}/.keep-account" ]; then
+            loginctl terminate-user "$user"
+        fi
     done
 done


### PR DESCRIPTION
Previously, users between 1000 and 3000 were not concerned by `clean-lurkers`.  Moreover, system users between 60000 and 65533 would have been wrongly terminated.
The inclusion of the range 65535-4294967294 is for future-proofing, since userdb and Debian explicitely support it.

Lastly, this fixed some potential issues with quoting, and replaced a use of `awk` with `cut`.