### PR TITLE
remove /usr/share/gocode and ~/.local/gocode from $GOPATH

### DIFF
--- a/profile.d/go.sh
+++ b/profile.d/go.sh
@@ -1,3 +1,3 @@
 # https://github.com/golang/go/wiki/GOPATH
-export GOPATH="/usr/share/gocode:$HOME/.local/gocode"
+export GOPATH="$HOME/go"
 export PATH="$GOPATH/bin:$PATH"


### PR DESCRIPTION
This will work with PR #153 to allow users to use go right away