### PR TITLE
man: Add hashbangctl to software list in hashbang.7 man page

### DIFF
--- a/man/man7/hashbang.7
+++ b/man/man7/hashbang.7
@@ -29,6 +29,8 @@ that has your private key.
 echo the foo file to the console
 
 .SH AVAILABLE SOFTWARE
+.SS Account Management
+hashbangctl - An account management program which can update your ssh keys, account name, and default shell.
 .SS Compilers / Interpreters / Programming Languages
 perl - A high-level, general-purpose dynamic programming language. Commonly
 referred to as "the duct tape of the internet."


### PR DESCRIPTION
Adding hashbangctl to the list of installed software would make it easier for new users to discover this tool.