### PR TITLE
export GOMAXPROCS=1

### DIFF
--- a/profile.d/go.sh
+++ b/profile.d/go.sh
@@ -1,3 +1,4 @@
 # https://github.com/golang/go/wiki/GOPATH
 export GOPATH="/usr/share/gocode:$HOME/.local/gocode"
 export PATH="$GOPATH/bin:$PATH"
+export GOMAXPROCS=1


### PR DESCRIPTION
sometimes when building a go program we reach max limits
to prevent crash, we can export GOMAXPROCS to 1