### PR TITLE
journald: Limit the amount of logs kept

### DIFF
--- a/systemd/journald.conf
+++ b/systemd/journald.conf
@@ -8,28 +8,6 @@
 # See journald.conf(5) for details
 
 [Journal]
-#Storage=auto
-#Compress=yes
-#Seal=yes
-#SplitMode=uid
-#SyncIntervalSec=5m
-#RateLimitInterval=30s
-#RateLimitBurst=1000
-#SystemMaxUse=
-#SystemKeepFree=
-#SystemMaxFileSize=
-#RuntimeMaxUse=
-#RuntimeKeepFree=
-#RuntimeMaxFileSize=
-#MaxRetentionSec=
-#MaxFileSec=1month
-#ForwardToSyslog=yes
-#ForwardToKMsg=no
-#ForwardToConsole=no
-#ForwardToWall=yes
-#TTYPath=/dev/console
-#MaxLevelStore=debug
-#MaxLevelSyslog=debug
-#MaxLevelKMsg=notice
-#MaxLevelConsole=info
-#MaxLevelWall=emerg
+MaxLevelStore=notice
+MaxRetentionSec=1month
+SystemMaxUse=1G


### PR DESCRIPTION
- Retain at most 1 GB or 1 month of logs (whichever comes first)
- Do not retain `info` and `debug` messages. `notice` and lower log-level messages are kept.