### PR TITLE
pam.d: Uniformly enforce pam_nologin

### DIFF
--- a/pam.d/common-account
+++ b/pam.d/common-account
@@ -13,6 +13,9 @@
 # pam-auth-update(8) for details.
 #
 
+# Disallow non-root logins when /etc/nologin exists.
+account	required	pam_nologin.so
+
 account	sufficient	pam_sss.so
 account	sufficient	pam_unix.so
 account	sufficient	pam_localuser.so

--- a/pam.d/login
+++ b/pam.d/login
@@ -31,10 +31,6 @@ auth       optional   pam_faildelay.so  delay=3000000
 # communicated over insecure lines.
 auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
 
-# Disallows other than root logins when /etc/nologin exists
-# (Replaces the `NOLOGINS_FILE' option from login.defs)
-auth       requisite  pam_nologin.so
-
 # SELinux needs to be the first session rule. This ensures that any 
 # lingering context has been cleared. Without out this it is possible 
 # that a module could execute code in the wrong domain.

--- a/pam.d/sshd
+++ b/pam.d/sshd
@@ -3,9 +3,6 @@
 # Standard Un*x authentication.
 @include common-auth
 
-# Disallow non-root logins when /etc/nologin exists.
-account    required     pam_nologin.so
-
 # Uncomment and edit /etc/security/access.conf if you need to set complex
 # access limits that are hard to express in sshd_config.
 # account  required     pam_access.so


### PR DESCRIPTION
Without this change, user sessions may be started anyhow (eg. by systemd).

This was mildly annoying while deploying the fixes for #167 