### PR TITLE
Disable polyinstanciation for /dev

### DIFF
--- a/security/namespace.conf
+++ b/security/namespace.conf
@@ -20,7 +20,7 @@
 # caution, as it will reduce security and isolation achieved by
 # polyinstantiation.
 #
-/dev      /dev/inst/           user      root
+#/dev      /dev/inst/           user      root
 /tmp      /tmp/inst/           user      root
 /var/tmp  /var/tmp/inst/       user      root
 /run/lock /run/lock/inst/      user      root

--- a/security/namespace.conf
+++ b/security/namespace.conf
@@ -2,12 +2,9 @@
 #
 # See /usr/share/doc/pam-*/txts/README.pam_namespace for more information.
 #
-# Uncommenting the following three lines will polyinstantiate
-# /tmp, /var/tmp and user's home directories. /tmp and /var/tmp will
-# be polyinstantiated based on the MLS level part of the security context as well as user
-# name, Polyinstantion will not be performed for user root and adm for directories
-# /tmp and /var/tmp, whereas home directories will be polyinstantiated for all users.
-# The user name and context is appended to the instance prefix.
+# /tmp, /var/tmp and /run/lock are polyinstantiated on a per-user basis,
+# resulting in each user having a different, private directory mounted
+# at those locations.
 #
 # Note that instance directories do not have to reside inside the
 # polyinstantiated directory. In the examples below, instances of /tmp


### PR DESCRIPTION
This seems to be the root cause for the session persistence issues that users have been encountering on `ny1` and `sf1` (see #75); a reboot -- or at least, terminating all user sessions -- is required to deploy this, but session persistence is currently broken anyhow.

This is a hotfix, to be deployed tonight at midnight EST (04:00 UTC), so please review before then.