### PR TITLE
Update mail server fingerprint

### DIFF
--- a/msmtprc
+++ b/msmtprc
@@ -14,7 +14,7 @@ maildomain hashbang.sh
 
 # TLS configuration
 tls on
-tls_fingerprint 73:E7:EC:E1:53:7F:D6:09:C9:3A:B3:62:84:64:7B:1D:D3:85:DF:D6
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
 
 # Syslog logging with facility LOG_MAIL instead of the default LOG_USER.
 # Only applies to the #! account


### PR DESCRIPTION
```
sendmail: TLS certificate verification failed: the certificate fingerprint does not match
sendmail: could not send mail (account default from /etc/msmtprc)
```