### PR TITLE
cron.daily/gpg-keyring: Fixup (forgot an argument to trap(1))

### DIFF
--- a/cron.daily/gpg-keyring
+++ b/cron.daily/gpg-keyring
@@ -4,7 +4,7 @@ KEYRING=/var/lib/hashbang/admins.gpg
 mkdir -p "$(dirname "${KEYRING}")"
 
 unset GNUPGHOME
-trap 'rm -rf -- "${GNUPGHOME}"'
+trap 'rm -rf -- "${GNUPGHOME}"' EXIT
 export GNUPGHOME="$(mktemp -d)"
 
 ADMIN_KEYS=(


### PR DESCRIPTION
Fixup for #186 