### PR TITLE
add `rlwrap`

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1121,6 +1121,7 @@ remind						install
 reportbug					install
 reptyr						install
 resolvconf					install
+rlwrap					install
 rsync						install
 rsyslog						install
 rtorrent					install


### PR DESCRIPTION
    Package: rlwrap
    Version: 0.42-3
    Installed-Size: 212
    Maintainer: Mike Miller <mtmiller@debian.org>
    Architecture: amd64
    Provides: readline-editor
    Depends: perl:any, libc6 (>= 2.15), libreadline7 (>= 6.0), libtinfo5 (>= 6)
    Description-en: readline feature command line wrapper
     This package provides a small utility that uses the GNU readline library
     to allow the editing of keyboard input for any other command.  Input
     history is remembered across invocations, separately for each command;
     history completion and search work as in bash and completion word lists
     can be specified on the command line.
    Description-md5: 2dd4e4df63ed824e61c4e21ad05cd1eb
    Homepage: https://github.com/hanslub42/rlwrap
    Tag: implemented-in::c, interface::commandline, interface::text-mode,
     role::program, scope::utility, uitoolkit::ncurses, works-with::text
    Section: utils
    Priority: optional
    Filename: pool/main/r/rlwrap/rlwrap_0.42-3_amd64.deb
    Size: 77798
    MD5sum: 356c6e5e994d7ebe4ee6ea827b68c906
    SHA256: bb38ffd9e1cd4cd42df16dc600d8cff18ec559defb06ecdfb6c9ccbba98f2cdc