### PR TITLE
systemd/system/crontab@.timer: Fix timing issues

### DIFF
--- a/systemd/system/crontab@.timer
+++ b/systemd/system/crontab@.timer
@@ -5,5 +5,5 @@ RefuseManualStart=yes
 RefuseManualStop=yes
 
 [Timer]
-OnCalendar=1 %I
+OnCalendar=%I
 Persistent=yes


### PR DESCRIPTION
Previously, the targets weren't run due to a formatting error.
Following the documentation here[1], this change removes the cause of
the syntax error.

[1]: https://www.freedesktop.org/software/systemd/man/systemd.time.html