### PR TITLE
cron.daily/gpg-keyring: Fix permissions issues

### DIFF
--- a/cron.daily/gpg-keyring
+++ b/cron.daily/gpg-keyring
@@ -3,7 +3,7 @@ KEYRING=/var/lib/hashbang/admins.gpg
 
 umask 002
 mkdir -p   "$(dirname "${KEYRING}")"
-chmod 0644 "$(dirname "${KEYRING}")"
+chmod 0755 "$(dirname "${KEYRING}")"
 
 unset GNUPGHOME
 trap 'rm -rf -- "${GNUPGHOME}"' EXIT


### PR DESCRIPTION
Commit 8535d26 introduced a bug when setting file permissions to `0644`
for the directory that the keyring is in. This fixes it by adding the
executable bits, so users can access files inside the directory.