### PR TITLE
sudo: Always allocate a new pseudo-terminal

### DIFF
--- a/sudoers
+++ b/sudoers
@@ -8,9 +8,9 @@
 #
 Defaults	env_reset
 Defaults	mail_badpass
-Defaults	!requiretty
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-Defaults	!tty_tickets
+Defaults	!requiretty, !tty_tickets
+Defaults	use_pty
 
 # Host alias specification
 


### PR DESCRIPTION
Otherwise, when switching to a privileged user (say, root) to an unprivileged user (say, a malicious shell user), the later can obtain access to a pty that is attached to a root session, once sudo exits.

See [TtyPushbackPrivilegeEscalation](https://www.halfdog.net/Security/2012/TtyPushbackPrivilegeEscalation/) and [saltty](https://github.com/JeCodeAvecLeQ/saltty) for the kind of issues this prevents.